### PR TITLE
Fix warning in WiFiConnect.h

### DIFF
--- a/WiFiConnect.h
+++ b/WiFiConnect.h
@@ -35,7 +35,7 @@ struct WiFiConnect
       //wifiManager.resetSettings(); 
       wifiManager.setSaveConfigCallback([&](){ shouldSaveConfig = true; });
       
-      sprintf(timezone, "%s", loadTimezone());
+      sprintf(timezone, "%s", loadTimezone().c_str());
       WiFiManagerParameter timezoneParam("tz", "Inform your timezone (e.g. America/Lima)", timezone, 36);
 
       wifiManager.setTitle("Clockwise Wifi Setup");


### PR DESCRIPTION
When compiling the code with '-Werror=format' the code fails to compile with this error:

```
WiFiConnect.h: In member function 'void WiFiConnect::connect()':
WiFiConnect.h:38:30: error: format '%s' expects argument of type 'char*', but argument 3 has type 'String' [-Werror=format=]
```

This PR changes the code to satisfy the expected argument type.