### PR TITLE
Add menu configuration option to swap Blue and Green colors.

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,0 +1,8 @@
+menu "Mario Clock Configuration"
+
+  config HUB75_BLUE_GREEN_SWAP
+    bool "Swap blue and green colors"
+    help
+        Some 64x64 HUB75 displays have the green and blue pins reversed. Enable this option to swap these pins.
+
+endmenu

--- a/main/mariobros-clock.cpp
+++ b/main/mariobros-clock.cpp
@@ -3,4 +3,10 @@
    so get around this limitation we create a .cpp file which includes the .ino file.
 */
 
+// Include the project configuration.
+// See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/kconfig.html for details.
+#include <sdkconfig.h>
+
+#define HUB75_BLUE_GREEN_SWAP CONFIG_HUB75_BLUE_GREEN_SWAP
+
 #include "../mariobros-clock.ino"

--- a/mariobros-clock.ino
+++ b/mariobros-clock.ino
@@ -24,6 +24,14 @@ void displaySetup() {
   mxconfig.gpio.e = 18;
   mxconfig.clkphase = false;
 
+#if HUB75_BLUE_GREEN_SWAP
+  // Swap Blue and Green pins because the panel is RBG instead of RGB.
+  mxconfig.gpio.b1 = 26;
+  mxconfig.gpio.b2 = 12;
+  mxconfig.gpio.g1 = 27;
+  mxconfig.gpio.g2 = 13;
+#endif
+
   // Display Setup
   dma_display = new MatrixPanel_I2S_DMA(mxconfig);
   dma_display->begin();


### PR DESCRIPTION
The HUB75 64x64 display that I purchased from Aliexpress had the B & G colors swapped. This seems to be a common problem that people are facing.

This code change adds code that will swap the B & G pins, as well as a menu configuration for esp-idf that makes it easy to enable/disable.